### PR TITLE
move `proxy_set_header` to advanced config

### DIFF
--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,9 +1,4 @@
   location {{ path }} {
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-Scheme $scheme;
-    proxy_set_header X-Forwarded-Proto  $scheme;
-    proxy_set_header X-Forwarded-For    $remote_addr;
-    proxy_set_header X-Real-IP		$remote_addr;
     proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
 
     {% if access_list_id > 0 %}

--- a/frontend/js/models/proxy-host-location.js
+++ b/frontend/js/models/proxy-host-location.js
@@ -7,7 +7,11 @@ const model = Backbone.Model.extend({
         return {
             opened:             false,
             path:               '',
-            advanced_config:    '',
+            advanced_config:    'proxy_set_header Host $host;\n' + 
+                                'proxy_set_header X-Forwarded-Scheme $scheme;\n' + 
+                                'proxy_set_header X-Forwarded-Proto  $scheme;\n' + 
+                                'proxy_set_header X-Forwarded-For    $remote_addr;\n' + 
+                                'proxy_set_header X-Real-IP          $remote_addr;',
             forward_scheme:     'http',
             forward_host:       '',
             forward_port:       '80'


### PR DESCRIPTION
This is completed copied from https://github.com/vivedo/nginx-proxy-manager/commit/cb28f983ee1b264ccdc93d8c28f0712622e6c3e7, as I currently do not know better ways to make a custom build.